### PR TITLE
Fixing choices values

### DIFF
--- a/src/Form/SettingFormType.php
+++ b/src/Form/SettingFormType.php
@@ -86,21 +86,15 @@ class SettingFormType extends AbstractType
                         'attr' => ['rows' => 12],
                     ]);
             } elseif ($model->getType()->equals(Type::CHOICE())) {
-                $choices = [];
-                foreach (array_flip($model->getChoices()) as $label => $value) {
-                    if (is_int($value)) {
-                        $choices[$label] = $label;
-                    } else {
-                        $choices[$label] = $value;
-                    }
-                }
                 $event
                     ->getForm()
                     ->add('data', ChoiceType::class, [
                         'translation_domain' => 'HelisSettingsManager',
                         'label' => 'edit.form.value',
                         'placeholder' => 'edit.form.choice_placeholder',
-                        'choices' => $choices
+                        'choices' => array_values($model->getChoices()) === $model->getChoices()
+                            ? array_combine($model->getChoices(), $model->getChoices())
+                            : $model->getChoices()
                     ]);
             } else {
                 $event

--- a/src/Form/SettingFormType.php
+++ b/src/Form/SettingFormType.php
@@ -86,13 +86,21 @@ class SettingFormType extends AbstractType
                         'attr' => ['rows' => 12],
                     ]);
             } elseif ($model->getType()->equals(Type::CHOICE())) {
+                $choices = [];
+                foreach (array_flip($model->getChoices()) as $label => $value) {
+                    if (is_int($value)) {
+                        $choices[$label] = $label;
+                    } else {
+                        $choices[$label] = $value;
+                    }
+                }
                 $event
                     ->getForm()
                     ->add('data', ChoiceType::class, [
                         'translation_domain' => 'HelisSettingsManager',
                         'label' => 'edit.form.value',
                         'placeholder' => 'edit.form.choice_placeholder',
-                        'choices' => $model->getChoices()
+                        'choices' => $choices
                     ]);
             } else {
                 $event


### PR DESCRIPTION
This PR is fixing the case of the user select `type: choice` and add choices values like: `['choice1', 'choice2']`. In this case the ouput by the **ChoiceType** will be:
```html
<option value="choice1">0</option>
<option value="choice2">1</option>
```

Tested with this 2 cases:
1. `choices: ['choice1', 'choice2']`
2. `choices: { choice1: 'Choice 1', choice2: 'Choice 2'}`