### PR TITLE
Phpbench

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,10 @@ before_install:
 install: composer update $COMPOSER_FLAGS
 
 script: ./vendor/bin/phpunit -c . -v
+
+jobs:
+  include:
+    - stage: Code Quality
+      php: 7.2
+      env: BENCHMARK
+      script: ./vendor/bin/phpbench run

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
     - libsodium-dev
 
 before_install:
-  - pecl install libsodium
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then pecl install libsodium; fi
   - pecl info redis
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - php -m

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ jobs:
     - stage: Code Quality
       php: 7.2
       env: BENCHMARK
-      script: ./vendor/bin/phpbench run
+      script: ./vendor/bin/phpbench run --progress=travis

--- a/benchmarks/Benchmark.php
+++ b/benchmarks/Benchmark.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Helis\SettingsManagerBundle\Benchmarks;
+
+/**
+ * @BeforeMethods({"setUp"})
+ * @AfterMethods({"tearDown"})
+ */
+abstract class Benchmark
+{
+    public function setUp(): void
+    {
+    }
+
+    public function tearDown(): void
+    {
+    }
+}

--- a/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
+++ b/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
@@ -126,7 +126,7 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
      * @ParamProviders({"provideDomainNames", "provideSettingNames"})
      * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="61")
+     * @Assert(stat="mean", value="71")
      */
     public function benchGetSettingsByName(array $params): void
     {

--- a/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
+++ b/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types=1);
+
+namespace Helis\SettingsManagerBundle\Benchmarks\Provider;
+
+use Helis\SettingsManagerBundle\Benchmarks\Benchmark;
+use Helis\SettingsManagerBundle\Provider\LazyReadableSimpleSettingsProvider;
+use Helis\SettingsManagerBundle\Serializer\Normalizer\DomainModelNormalizer;
+use Helis\SettingsManagerBundle\Serializer\Normalizer\SettingModelNormalizer;
+use Helis\SettingsManagerBundle\Serializer\Normalizer\TagModelNormalizer;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class LazyReadableSimpleSettingsProviderBench extends Benchmark
+{
+    /**
+     * @var LazyReadableSimpleSettingsProvider
+     */
+    protected $provider;
+
+    public function setUp(): void
+    {
+        $normSettingsByDomain = [];
+        $normDomains = [];
+
+        for ($i = 0; $i < 150; $i++) {
+            $domainName = 'domain_' . $i;
+            $domain = [
+                'name' => $domainName,
+                'enabled' => ($i % 3) !== 0,
+                'read_only' => false,
+                'priority' => 0,
+            ];
+            $normDomains[$domainName] = $domain;
+        }
+
+        for ($i = 0; $i < 300; $i++) {
+            $domainName = 'domain_' . $i % 150;
+            $settingName = 'setting_' . $i;
+
+            $normSettingsByDomain[$domainName][$settingName] = [
+                'name' => $settingName,
+                'description' => 'It\'s not who I am underneath but what I do that defines me.',
+                'domain' => $normDomains[$domainName],
+                'type' => 'bool',
+                'data' => ['value' => $i % 2],
+            ];
+        }
+
+        $this->provider = new LazyReadableSimpleSettingsProvider(
+            new Serializer(
+                [
+                    new ArrayDenormalizer(),
+                    new SettingModelNormalizer(),
+                    new DomainModelNormalizer(),
+                    new TagModelNormalizer(),
+                ],
+                [
+                    new JsonEncoder()
+                ]
+            ),
+            $normSettingsByDomain,
+            $normDomains
+        );
+    }
+
+    public function provideDomainNames()
+    {
+        #0: first 50 domains
+        $domainNames = [];
+        for ($i = 0; $i < 50; $i++) {
+            $domainNames[] = 'domain_' . $i;
+        }
+        yield 'first 50 domains' => ['domainNames' => $domainNames];
+
+        #1: first 100 domains
+        for ($i = 50; $i < 100; $i++) {
+            $domainNames[] = 'domain_' . $i;
+        }
+        yield 'first 100 domains' => ['domainNames' => $domainNames];
+
+        #2: from 100 to 150 domains
+        $domainNames = [];
+        for ($i = 100; $i < 150; $i++) {
+            $domainNames[] = 'domain_' . $i;
+        }
+        yield 'from 100 to 150 domains' => ['domainNames' => $domainNames];
+
+        #3: from 50 to 150 domains
+        $domainNames = [];
+        for ($i = 50; $i < 150; $i++) {
+            $domainNames[] = 'domain_' . $i;
+        }
+        yield 'from 50 to 150 domains' => ['domainNames' => $domainNames];
+    }
+
+    public function provideSettingNames()
+    {
+        #0: first 50 settings
+        $settingNames = [];
+        for ($i = 0; $i < 50; $i++) {
+            $settingNames[] = 'setting_' . $i;
+        }
+        yield 'first 50 settings' => ['settingNames' => $settingNames];
+    }
+
+    /**
+     * @ParamProviders({"provideDomainNames"})
+     * @Revs(1000)
+     * @Iterations(5)
+     * @Assert(stat="mean", value="30")
+     */
+    public function benchGetSettings(array $params): void
+    {
+        $this->provider->getSettings($params['domainNames']);
+    }
+
+    /**
+     * @ParamProviders({"provideDomainNames", "provideSettingNames"})
+     * @Revs(500)
+     * @Iterations(5)
+     * @Assert(stat="mean", value="30")
+     */
+    public function benchGetSettingsByName(array $params): void
+    {
+        $this->provider->getSettingsByName($params['domainNames'], $params['settingNames']);
+    }
+
+    /**
+     * @Revs(1000)
+     * @Iterations(5)
+     * @Assert(stat="mean", value="10")
+     */
+    public function benchGetDomains(): void
+    {
+        $this->provider->getDomains();
+    }
+
+    /**
+     * @Revs(1000)
+     * @Iterations(5)
+     * @Assert(stat="mean", value="10")
+     */
+    public function benchGetEnabedDomains(): void
+    {
+        $this->provider->getDomains(true);
+    }
+}

--- a/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
+++ b/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
@@ -21,31 +21,35 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
 
     public function setUp(): void
     {
-        $normSettingsByDomain = [];
+        $normSettings = [];
         $normDomains = [];
+
+        $settingsKeyMap = [];
+        $domainsKeyMap = [];
 
         for ($i = 0; $i < 150; $i++) {
             $domainName = 'domain_' . $i;
-            $domain = [
+            $normDomains[$domainName] = [
                 'name' => $domainName,
                 'enabled' => ($i % 3) !== 0,
                 'read_only' => false,
                 'priority' => 0,
             ];
-            $normDomains[$domainName] = $domain;
         }
 
         for ($i = 0; $i < 300; $i++) {
             $domainName = 'domain_' . $i % 150;
             $settingName = 'setting_' . $i;
-
-            $normSettingsByDomain[$domainName][$settingName] = [
+            $settingKey = $domainName.'_'.$settingName;
+            $normSettings[$settingKey] = [
                 'name' => $settingName,
                 'description' => 'It\'s not who I am underneath but what I do that defines me.',
                 'domain' => $normDomains[$domainName],
                 'type' => 'bool',
                 'data' => ['value' => $i % 2],
             ];
+
+            $settingsKeyMap[$settingName][] = $domainsKeyMap[$domainName][] = $settingKey;
         }
 
         $this->provider = new LazyReadableSimpleSettingsProvider(
@@ -60,8 +64,10 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
                     new JsonEncoder()
                 ]
             ),
-            $normSettingsByDomain,
-            $normDomains
+            $normDomains,
+            $normSettings,
+            $settingsKeyMap,
+            $domainsKeyMap
         );
     }
 
@@ -109,7 +115,7 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
      * @ParamProviders({"provideDomainNames"})
      * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="36")
+     * @Assert(stat="mean", value="61")
      */
     public function benchGetSettings(array $params): void
     {
@@ -120,7 +126,7 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
      * @ParamProviders({"provideDomainNames", "provideSettingNames"})
      * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="36")
+     * @Assert(stat="mean", value="61")
      */
     public function benchGetSettingsByName(array $params): void
     {

--- a/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
+++ b/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
@@ -109,7 +109,7 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
      * @ParamProviders({"provideDomainNames"})
      * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="31")
+     * @Assert(stat="mean", value="36")
      */
     public function benchGetSettings(array $params): void
     {
@@ -120,7 +120,7 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
      * @ParamProviders({"provideDomainNames", "provideSettingNames"})
      * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="31")
+     * @Assert(stat="mean", value="36")
      */
     public function benchGetSettingsByName(array $params): void
     {

--- a/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
+++ b/benchmarks/Provider/LazyReadableSimpleSettingsProviderBench.php
@@ -109,7 +109,7 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
      * @ParamProviders({"provideDomainNames"})
      * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="30")
+     * @Assert(stat="mean", value="31")
      */
     public function benchGetSettings(array $params): void
     {
@@ -118,9 +118,9 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
 
     /**
      * @ParamProviders({"provideDomainNames", "provideSettingNames"})
-     * @Revs(500)
+     * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="30")
+     * @Assert(stat="mean", value="31")
      */
     public function benchGetSettingsByName(array $params): void
     {
@@ -130,7 +130,7 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
     /**
      * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="10")
+     * @Assert(stat="mean", value="11")
      */
     public function benchGetDomains(): void
     {
@@ -140,7 +140,7 @@ class LazyReadableSimpleSettingsProviderBench extends Benchmark
     /**
      * @Revs(1000)
      * @Iterations(5)
-     * @Assert(stat="mean", value="10")
+     * @Assert(stat="mean", value="11")
      */
     public function benchGetEnabedDomains(): void
     {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "autoload-dev": {
         "psr-4": {
             "Helis\\SettingsManagerBundle\\Tests\\": "tests/src/",
+            "Helis\\SettingsManagerBundle\\Benchmarks\\": "benchmarks/",
             "App\\": "tests/bundle/"
         },
         "classmap": ["tests/app/AppKernel.php"]
@@ -51,6 +52,7 @@
         "knplabs/knp-menu-bundle": "^2.2",
         "liip/functional-test-bundle": ">=2.0.0-alpha1 <=2.0.0-alpha8",
         "paragonie/paseto": "^1.0",
+        "phpbench/phpbench": "^0.15.0",
         "phpunit/phpunit": "^6.5",
         "predis/predis": "^1.1",
         "symfony/asset": "^3.4|^4.0",

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,5 @@
+{
+  "bootstrap": "vendor/autoload.php",
+  "path": "benchmarks",
+  "time_unit": "milliseconds"
+}

--- a/src/DependencyInjection/HelisSettingsManagerExtension.php
+++ b/src/DependencyInjection/HelisSettingsManagerExtension.php
@@ -117,39 +117,37 @@ class HelisSettingsManagerExtension extends Extension
                     'provider' => SettingsProviderInterface::DEFAULT_PROVIDER,
                     'priority' => $config['settings_config']['priority'],
                 ]);
+        } else {
+            $normDomains = [];
+            $normSettings = [];
+            $settingsKeyMap = [];
+            $domainsKeyMap = [];
 
-            return;
+            foreach ($settings as $setting) {
+                $domainName = $setting['domain']['name'];
+                $settingName = $setting['name'];
+                $settingKey = $domainName.'_'.$settingName;
+
+                $normDomains[$domainName] = $setting['domain'];
+                $normSettings[$settingKey] = $setting;
+                $settingsKeyMap[$settingName][] = $domainsKeyMap[$domainName][] = $settingKey;
+            }
+
+            $container
+                ->register('settings_manager.provider.config', LazyReadableSimpleSettingsProvider::class)
+                ->setArguments([
+                    new Reference('settings_manager.serializer'),
+                    $normDomains,
+                    $normSettings,
+                    $settingsKeyMap,
+                    $domainsKeyMap,
+                ])
+                ->setPublic(false)
+                ->addTag('settings_manager.provider', [
+                    'provider' => SettingsProviderInterface::DEFAULT_PROVIDER,
+                    'priority' => $config['settings_config']['priority'],
+                ]);
         }
-
-        $normDomains = [];
-        $normSettings = [];
-        $settingsKeyMap = [];
-        $domainsKeyMap = [];
-
-        foreach ($settings as $setting) {
-            $domainName = $setting['domain']['name'];
-            $settingName = $setting['name'];
-            $settingKey = $domainName.'_'.$settingName;
-
-            $normDomains[$domainName] = $setting['domain'];
-            $normSettings[$settingKey] = $setting;
-            $settingsKeyMap[$settingName][] = $domainsKeyMap[$domainName][] = $settingKey;
-        }
-
-        $container
-            ->register('settings_manager.provider.config', LazyReadableSimpleSettingsProvider::class)
-            ->setArguments([
-                new Reference('settings_manager.serializer'),
-                $normDomains,
-                $normSettings,
-                $settingsKeyMap,
-                $domainsKeyMap,
-            ])
-            ->setPublic(false)
-            ->addTag('settings_manager.provider', [
-                'provider' => SettingsProviderInterface::DEFAULT_PROVIDER,
-                'priority' => $config['settings_config']['priority'],
-            ]);
 
         $container
             ->register('settings_manager.provider.config.decorating', DecoratingInMemorySettingsProvider::class)

--- a/src/Provider/DecoratingInMemorySettingsProvider.php
+++ b/src/Provider/DecoratingInMemorySettingsProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Helis\SettingsManagerBundle\Provider;
 
 use Helis\SettingsManagerBundle\Provider\Traits\ReadOnlyProviderTrait;

--- a/src/Provider/DecoratingInMemorySettingsProvider.php
+++ b/src/Provider/DecoratingInMemorySettingsProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Helis\SettingsManagerBundle\Provider;
+
+use Helis\SettingsManagerBundle\Provider\Traits\ReadOnlyProviderTrait;
+
+class DecoratingInMemorySettingsProvider implements SettingsProviderInterface
+{
+    use ReadOnlyProviderTrait;
+
+    private $settingsProvider;
+    private $cacheMap;
+
+    public function __construct(SettingsProviderInterface $settingsProvider)
+    {
+        if (!$settingsProvider->isReadOnly()) {
+            throw new \InvalidArgumentException('DecoratingInMemorySettingsProvider can only decorate read only provider');
+        }
+
+        $this->settingsProvider = $settingsProvider;
+        $this->cacheMap = [];
+    }
+
+    public function getSettings(array $domainNames): array
+    {
+        $cacheKey = json_encode(['domainNames' => $domainNames]);
+        if (!isset($this->cache[$cacheKey])) {
+            $this->cacheMap[$cacheKey] = $this->settingsProvider->getSettings($domainNames);
+        }
+
+        return $this->cacheMap[$cacheKey];
+    }
+
+    public function getSettingsByName(array $domainNames, array $settingNames): array
+    {
+        $cacheKey = json_encode(['domainNames' => $domainNames, 'settingNames' => $settingNames]);
+        if (!isset($this->cache[$cacheKey])) {
+            $this->cacheMap[$cacheKey] = $this->settingsProvider->getSettingsByName($domainNames, $settingNames);
+        }
+
+        return $this->cacheMap[$cacheKey];
+    }
+
+    public function getDomains(bool $onlyEnabled = false): array
+    {
+        $cacheKey = $onlyEnabled ? 'domains_only_enabled' : 'domains';
+        if (!isset($this->cache[$cacheKey])) {
+            $this->cacheMap[$cacheKey] = $this->settingsProvider->getDomains($onlyEnabled);
+        }
+
+        return $this->cacheMap[$cacheKey];
+    }
+}

--- a/src/Provider/LazyReadableSimpleSettingsProvider.php
+++ b/src/Provider/LazyReadableSimpleSettingsProvider.php
@@ -11,75 +11,80 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 class LazyReadableSimpleSettingsProvider extends ReadableSimpleSettingsProvider
 {
     private $serializer;
-    private $normSettingsByDomain;
     private $normDomains;
+    private $normSettings;
 
-    private $modelSettingsByDomain;
+    private $settingsKeyMap;
+    private $domainsKeyMap;
+
+    private $modelSettings;
     private $modelDomains;
     private $modelDomainsEnabled;
 
     public function __construct(
         DenormalizerInterface $serializer,
-        array $normSettingsByDomain,
-        array $normDomains
+        array $normDomains,
+        array $normSettings,
+        array $settingsKeyMap,
+        array $domainsKeyMap
     ) {
         parent::__construct([]);
 
         $this->serializer = $serializer;
-        $this->normSettingsByDomain = $normSettingsByDomain;
         $this->normDomains = $normDomains;
+        $this->normSettings = $normSettings;
 
-        $this->modelSettingsByDomain = [];
+        $this->settingsKeyMap = $settingsKeyMap;
+        $this->domainsKeyMap = $domainsKeyMap;
+
+        $this->modelSettings = [];
         $this->modelDomains = [];
         $this->modelDomainsEnabled = [];
     }
 
     public function getSettings(array $domainNames): array
     {
-        $modelSettingsByDomain = array_intersect_key($this->modelSettingsByDomain, array_flip($domainNames));
-        $normSettingsByDomain = array_intersect_key($this->normSettingsByDomain, array_flip($domainNames));
+        $keys = array_intersect_key($this->domainsKeyMap, array_flip($domainNames));
+        if (empty($keys)) {
+            return [];
+        }
+        $keys = array_merge(...array_values($keys));
+        $normSettings = array_intersect_key($this->normSettings, array_flip($keys));
 
-        foreach ($normSettingsByDomain as $domainName => $normSettings) {
-            $this->modelSettingsByDomain[$domainName] = array_replace(
-                $this->modelSettingsByDomain[$domainName] ?? [],
-                $this->serializer->denormalize($normSettings, SettingModel::class . '[]')
-            );
-            $modelSettingsByDomain[$domainName] = array_replace($modelSettingsByDomain[$domainName] ?? [], $this->modelSettingsByDomain[$domainName]);
-            unset($this->normSettingsByDomain[$domainName]);
+        if (!empty($normSettings)) {
+            $modelSettings = $this->serializer->denormalize($normSettings, SettingModel::class . '[]');
+            $this->modelSettings = array_merge($this->modelSettings, $modelSettings);
+            $this->normSettings = array_diff_key($this->normSettings, $modelSettings);
         }
 
-        return empty($modelSettingsByDomain)
-            ? []
-            : array_merge_recursive(...array_values($modelSettingsByDomain));
+        $modelSettings = array_intersect_key($this->modelSettings, array_flip($keys));
+
+        return empty($modelSettings) ? [] : array_values($modelSettings);
     }
 
     public function getSettingsByName(array $domainNames, array $settingNames): array
     {
-        $normSettingsByDomain = array_intersect_key($this->normSettingsByDomain, array_flip($domainNames));
-        $modelSettingsByDomain = array_intersect_key($this->modelSettingsByDomain, array_flip($domainNames));
-
-        if (!empty($normSettingsByDomain)) {
-            $normSettings = array_intersect_key(array_merge(...array_values($normSettingsByDomain)), array_flip($settingNames));
-
-            if (!empty($normSettings)) {
-                /** @var SettingModel[] $settings */
-                $settings = $this->serializer->denormalize($normSettings, SettingModel::class . '[]');
-                foreach ($settings as $setting) {
-                    $this->modelSettingsByDomain[$setting->getDomain()->getName()][$setting->getName()]
-                        = $modelSettingsByDomain[$setting->getDomain()->getName()][$setting->getName()]
-                        = $setting;
-
-                    unset($this->normSettingsByDomain[$setting->getDomain()->getName()][$setting->getName()]);
-                    if (empty($this->normSettingsByDomain[$setting->getDomain()->getName()])) {
-                        unset($this->normSettingsByDomain[$setting->getDomain()->getName()]);
-                    }
-                }
-            }
+        $settingKeys = array_intersect_key($this->settingsKeyMap, array_flip($settingNames));
+        $domainKeys = array_intersect_key($this->domainsKeyMap, array_flip($domainNames));
+        if (empty($settingKeys) || empty($domainKeys)) {
+            return [];
         }
 
-        return empty($modelSettingsByDomain)
-            ? []
-            : array_intersect_key(array_merge(...array_values($modelSettingsByDomain)), array_flip($settingNames));
+        $keys = array_flip(array_intersect(
+            array_merge(...array_values($settingKeys)),
+            array_merge(...array_values($domainKeys)))
+        );
+        $normSettings = array_intersect_key($this->normSettings, $keys);
+
+        if (!empty($normSettings)) {
+            $modelSettings = $this->serializer->denormalize($normSettings, SettingModel::class . '[]');
+            $this->modelSettings = array_merge($this->modelSettings, $modelSettings);
+            $this->normSettings = array_diff_key($this->normSettings, $modelSettings);
+        }
+
+        $modelSettings = array_intersect_key($this->modelSettings, $keys);
+
+        return empty($modelSettings) ? [] : array_values($modelSettings);
     }
 
     public function getDomains(bool $onlyEnabled = false): array

--- a/tests/src/Functional/Provider/AbstractReadableSettingsProviderTest.php
+++ b/tests/src/Functional/Provider/AbstractReadableSettingsProviderTest.php
@@ -86,12 +86,21 @@ abstract class AbstractReadableSettingsProviderTest extends WebTestCase
             ->setDomain($domain3)
             ->setData(1.2);
 
+        $setting5 = new Setting();
+        $setting5
+            ->setName('bazinga')
+            ->setDescription('fixture bool baz setting')
+            ->setType(Type::BOOL())
+            ->setDomain($domain3)
+            ->setData(true);
+
         return [
             $setting0,
             $setting1,
             $setting2,
             $setting3,
             $setting4,
+            $setting5,
         ];
     }
 
@@ -110,6 +119,7 @@ abstract class AbstractReadableSettingsProviderTest extends WebTestCase
                 [
                     ['banana', 'apples', 'int', 10],
                     ['bazinga', 'default', 'bool', false],
+                    ['bazinga', 'apples', 'bool', true],
                     ['foo', 'default', 'bool', true],
                     ['kiwi', 'apples', 'float', 1.2],
                 ],
@@ -119,6 +129,7 @@ abstract class AbstractReadableSettingsProviderTest extends WebTestCase
                 [
                     ['banana', 'apples', 'int', 10],
                     ['bazinga', 'default', 'bool', false],
+                    ['bazinga', 'apples', 'bool', true],
                     ['foo', 'default', 'bool', true],
                     ['kiwi', 'apples', 'float', 1.2],
                     ['tuna', 'sea', 'string', 'fishing'],
@@ -144,11 +155,11 @@ abstract class AbstractReadableSettingsProviderTest extends WebTestCase
         }, $settings);
 
         usort($map, function ($a, $b) {
-            return $a[0] <=> $b[0];
+            return $a[0].$a[1] <=> $b[0].$b[1];
         });
 
         usort($expectedSettingsMap, function ($a, $b) {
-            return $a[0] <=> $b[0];
+            return $a[0].$a[1] <=> $b[0].$b[1];
         });
 
         $this->assertEquals($expectedSettingsMap, $map);
@@ -169,6 +180,15 @@ abstract class AbstractReadableSettingsProviderTest extends WebTestCase
                 ['bazinga', 'foo'],
                 [
                     ['bazinga', 'default', 'bool', false],
+                    ['foo', 'default', 'bool', true],
+                ]
+            ],
+            [
+                ['default', 'apples'],
+                ['bazinga', 'foo'],
+                [
+                    ['bazinga', 'default', 'bool', false],
+                    ['bazinga', 'apples', 'bool', true],
                     ['foo', 'default', 'bool', true],
                 ]
             ],
@@ -218,11 +238,11 @@ abstract class AbstractReadableSettingsProviderTest extends WebTestCase
         }, $settings);
 
         usort($map, function ($a, $b) {
-            return $a[0] <=> $b[0];
+            return $a[0].$a[1] <=> $b[0].$b[1];
         });
 
         usort($expectedSettingsMap, function ($a, $b) {
-            return $a[0] <=> $b[0];
+            return $a[0].$a[1] <=> $b[0].$b[1];
         });
 
         $this->assertEquals($map, $expectedSettingsMap);

--- a/tests/src/Functional/Provider/AbstractSettingsProviderTest.php
+++ b/tests/src/Functional/Provider/AbstractSettingsProviderTest.php
@@ -137,7 +137,7 @@ abstract class AbstractSettingsProviderTest extends AbstractReadableSettingsProv
         $this->assertArrayHasKey('apples', $domains);
         $domainToUpdate = $domains['apples'];
         $settings = $this->provider->getSettings(['apples']);
-        $this->assertCount(2, $settings);
+        $this->assertCount(3, $settings);
 
         $this->assertFalse($domainToUpdate->isEnabled());
         $this->assertEquals(0, $domainToUpdate->getPriority());
@@ -156,7 +156,7 @@ abstract class AbstractSettingsProviderTest extends AbstractReadableSettingsProv
         $this->assertArrayHasKey('apples', $domains);
         $domainToUpdate = $domains['apples'];
         $settings = $this->provider->getSettings(['apples']);
-        $this->assertCount(2, $settings);
+        $this->assertCount(3, $settings);
 
         $this->assertTrue($domainToUpdate->isEnabled());
         $this->assertEquals(11, $domainToUpdate->getPriority());

--- a/tests/src/Functional/Provider/DecoratingRedisSettingsProviderTest.php
+++ b/tests/src/Functional/Provider/DecoratingRedisSettingsProviderTest.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace Helis\SettingsManagerBundle\Tests\Functional\Provider;
 
-use Helis\SettingsManagerBundle\Provider\DecoratingRedisSettingsProvider;
-use Helis\SettingsManagerBundle\Provider\DoctrineOrmSettingsProvider;
 use App\Entity\Setting;
 use App\Entity\Tag;
+use Helis\SettingsManagerBundle\Provider\DecoratingRedisSettingsProvider;
+use Helis\SettingsManagerBundle\Provider\DoctrineOrmSettingsProvider;
 use Helis\SettingsManagerBundle\Provider\SettingsProviderInterface;
 
-class RedisDoctrineOrmSettingsProviderTest extends DecoratingPredisSettingsProviderTest
+class DecoratingRedisSettingsProviderTest extends DecoratingPredisSettingsProviderTest
 {
     protected function createProvider(): SettingsProviderInterface
     {
@@ -19,7 +19,11 @@ class RedisDoctrineOrmSettingsProviderTest extends DecoratingPredisSettingsProvi
 
         $this->redis = new \Redis();
 
-        if (@$this->redis->connect(getenv('REDIS_HOST'), (int) getenv('REDIS_PORT'), 1.0) === false) {
+        try {
+            if (!@$this->redis->connect(getenv('REDIS_HOST'), (int) getenv('REDIS_PORT'), 1.0)) {
+                $this->markTestSkipped('Running redis server required');
+            }
+        } catch (\RedisException $e) {
             $this->markTestSkipped('Running redis server required');
         }
 

--- a/tests/src/Functional/Provider/LazyReadableSimpleSettingsProviderTest.php
+++ b/tests/src/Functional/Provider/LazyReadableSimpleSettingsProviderTest.php
@@ -11,14 +11,21 @@ class LazyReadableSimpleSettingsProviderTest extends AbstractReadableSettingsPro
     protected function createProvider(): SettingsProviderInterface
     {
         $serializer = $this->getContainer()->get('settings_manager.serializer');
-        $normalizedSettingsByDomain = [];
-        $normalizedDomains = [];
+        $normDomains = [];
+        $normSettings = [];
+        $settingsKeyMap = [];
+        $domainsKeyMap = [];
 
-        foreach ($serializer->normalize($this->getSettingFixtures()) as $normalizedSetting) {
-            $normalizedSettingsByDomain[$normalizedSetting['domain']['name']][$normalizedSetting['name']] = $normalizedSetting;
-            $normalizedDomains[$normalizedSetting['domain']['name']] = $normalizedSetting['domain'];
+        foreach ($serializer->normalize($this->getSettingFixtures()) as $setting) {
+            $domainName = $setting['domain']['name'];
+            $settingName = $setting['name'];
+            $settingKey = $domainName.'_'.$settingName;
+
+            $normDomains[$domainName] = $setting['domain'];
+            $normSettings[$settingKey] = $setting;
+            $settingsKeyMap[$settingName][] = $domainsKeyMap[$domainName][] = $settingKey;
         }
 
-        return new LazyReadableSimpleSettingsProvider($serializer, $normalizedSettingsByDomain, $normalizedDomains);
+        return new LazyReadableSimpleSettingsProvider($serializer, $normDomains, $normSettings, $settingsKeyMap, $domainsKeyMap);
     }
 }


### PR DESCRIPTION
 - Initial setting get from `LazyReadableSimpleSettingsProvider` which is default provider for settings from yaml improved speed about 10 times (benchmarked with 100 domains and 300 settings).
 - Also `LazyReadableSimpleSettingsProvider` is now being decorated by a new `
DecoratingInMemorySettingsProvider` which will cache by arguments settings to avoid rebuilding key maps.