### PR TITLE
Proposal: Adding new debug command

### DIFF
--- a/src/Command/SettingsDebugCommand.php
+++ b/src/Command/SettingsDebugCommand.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Helis\SettingsManagerBundle\Command;
+
+use Helis\SettingsManagerBundle\Model\SettingModel;
+use Helis\SettingsManagerBundle\Provider\SettingsProviderInterface;
+use Helis\SettingsManagerBundle\Settings\SettingsManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Class SettingsDebugCommand
+ *
+ * @package Helis\SettingsManagerBundle\Command
+ */
+class SettingsDebugCommand extends Command
+{
+
+    protected static $defaultName = 'debug:settings';
+
+    /** @var SettingsManager $settingsManager */
+    protected $settingsManager;
+
+    /**
+     * SettingsDebugCommand constructor.
+     *
+     * @param SettingsManager $settingsManager
+     */
+    public function __construct(SettingsManager $settingsManager)
+    {
+        parent::__construct();
+        $this->settingsManager = $settingsManager;
+    }
+
+    /**
+     * Configures the current command.
+     */
+    protected function configure()
+    {
+        $this->setDefinition([
+            new InputArgument('name', InputArgument::OPTIONAL, 'A setting name'),
+            new InputOption('domain', null, InputOption::VALUE_REQUIRED, 'Displays settings for a specific domain'),
+            new InputOption('domains', null, InputOption::VALUE_NONE, 'Displays all configured domains'),
+            new InputOption('tag', null, InputOption::VALUE_REQUIRED, 'Shows all settings with a specific tag'),
+        ])->setDescription('Displays current settings for an application')->setHelp(<<<'EOF'
+The <info>%command.name%</info> command displays all available settings:
+
+  <info>php %command.full_name%</info>
+
+Use the <info>--domains</info> option to display all configured domains:
+
+  <info>php %command.full_name% --parameters</info>
+
+Display settings for a specific domain by specifying its name with the <info>--domain</info> option:
+
+  <info>php %command.full_name% --domain=default</info>
+
+Find all settings with a specific tag by specifying the tag name with the <info>--tag</info> option:
+
+  <info>php %command.full_name% --tag=foo</info>
+
+EOF
+        );
+    }
+
+    /**
+     * Executes the current command.
+     * This method is not abstract because you can use this class
+     * as a concrete class. In this case, instead of defining the
+     * execute() method, you set the code to execute by passing
+     * a Closure to the setCode() method.
+     *
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return void null or 0 if everything went fine, or an error code
+     * @see setCode()
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        // // Displays all configured domains
+        if ($input->getOption('domains')) {
+            $tableHeaders = ['Name', 'Priority', 'Enabled', 'Read only'];
+            $tableRows    = [];
+            foreach ($this->settingsManager->getDomains() as $key => $domain) {
+                $tableRows[] = [
+                    $domain->getName(),
+                    $domain->getPriority(),
+                    $domain->isEnabled(),
+                    $domain->isReadOnly()
+                ];
+            }
+            $io->table($tableHeaders, $tableRows);
+        }
+
+        // Filter by domain(s)
+        $domains = array_keys($this->settingsManager->getDomains());
+        if ($input->getOption('domain')) {
+            $domains = [$input->getOption('domain')];
+        }
+
+        // Displays table of settings
+        if (!$input->getOption('domains') && !$input->getArgument('name')) {
+            $tableHeaders = ['Name', 'Description', 'Domain', 'Type', 'Data', 'Provider name', 'Tags'];
+            $tableRows    = [];
+
+            // Display settings filtered by tags
+            if ($tag = $input->getOption('tag')) {
+                foreach (array_reverse($this->settingsManager->getEnabledSettingsByTag($domains,
+                    $tag)) as $settingModel) {
+                    $tableRows[] = $this->_renderSettingsRow($settingModel);
+                }
+            } // Display all settings
+            else {
+                /** @var SettingsProviderInterface $provider */
+                foreach (array_reverse($this->settingsManager->getProviders()) as $pName => $provider) {
+                    foreach ($provider->getSettings($domains) as $settingModel) {
+                        $tableRows[] = $this->_renderSettingsRow($settingModel);
+                    }
+                }
+            }
+
+            $io->table($tableHeaders, $tableRows);
+        }
+
+        // Display details for one setting with argument `name`
+        if ($name = $input->getArgument('name')) {
+            $io->title(sprintf('Information for Setting "<info>%s</info>"', $name));
+
+            $setting = $this->settingsManager->getSettingsByName($domains, [$name]);
+            $setting = array_shift($setting);
+
+            $tableHeaders = ['Option', 'Value'];
+            $tableRows[]  = ['Name', $setting->getName()];
+            $tableRows[]  = ['Description', $setting->getDescription() ?? '-'];
+            $tableRows[]  = ['Domain', $setting->getDomain()->getName()];
+            $tableRows[]  = ['Provider Name', $setting->getProviderName() ?? 'config'];
+            $tableRows[]  = ['Type', $setting->getType()->getValue()];
+
+            if ($tags = $setting->getTags()) {
+                $tagInformation = [];
+                foreach ($tags as $tag) {
+                    $tagInformation[] = $tag->getName();
+                }
+                $tagInformation = implode("\n", $tagInformation);
+            } else {
+                $tagInformation = '-';
+            }
+            $tableRows[] = ['Tags', $tagInformation];
+            $tableRows[] = ['Choices', ($choices = $setting->getChoices()) ? var_export($choices, true) : '-'];
+            $tableRows[] = ['Data', $setting->getData()];
+
+            $io->table($tableHeaders, $tableRows);
+        }
+    }
+
+    /**
+     * @param SettingModel $settingModel
+     *
+     * @return array
+     */
+    private function _renderSettingsRow(SettingModel $settingModel): array
+    {
+        if ($tags = $settingModel->getTags()) {
+            $tagInformation = [];
+            foreach ($tags as $tag) {
+                $tagInformation[] = $tag->getName();
+            }
+            $tagInformation = implode("\n", $tagInformation);
+        } else {
+            $tagInformation = '-';
+        }
+
+        return [
+            $settingModel->getName(),
+            $settingModel->getDescription(),
+            $settingModel->getDomain()->getName(),
+            $settingModel->getType()->getValue(),
+            $settingModel->getData(),
+            $settingModel->getProviderName() ?? 'config',
+            $tagInformation
+        ];
+    }
+}

--- a/src/Command/SettingsDebugCommand.php
+++ b/src/Command/SettingsDebugCommand.php
@@ -53,7 +53,7 @@ The <info>%command.name%</info> command displays all available settings:
 
 Use the <info>--domains</info> option to display all configured domains:
 
-  <info>php %command.full_name% --parameters</info>
+  <info>php %command.full_name% --domains</info>
 
 Display settings for a specific domain by specifying its name with the <info>--domain</info> option:
 

--- a/src/Command/SettingsDebugCommand.php
+++ b/src/Command/SettingsDebugCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Helis\SettingsManagerBundle\Command;
 
 use Helis\SettingsManagerBundle\Model\SettingModel;
@@ -13,13 +15,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * Class SettingsDebugCommand
- *
- * @package Helis\SettingsManagerBundle\Command
+ * Class SettingsDebugCommand.
  */
 class SettingsDebugCommand extends Command
 {
-
     protected static $defaultName = 'debug:settings';
 
     /** @var SettingsManager $settingsManager */
@@ -46,7 +45,8 @@ class SettingsDebugCommand extends Command
             new InputOption('domain', null, InputOption::VALUE_REQUIRED, 'Displays settings for a specific domain'),
             new InputOption('domains', null, InputOption::VALUE_NONE, 'Displays all configured domains'),
             new InputOption('tag', null, InputOption::VALUE_REQUIRED, 'Shows all settings with a specific tag'),
-        ])->setDescription('Displays current settings for an application')->setHelp(<<<'EOF'
+        ])->setDescription('Displays current settings for an application')->setHelp(
+            <<<'EOF'
 The <info>%command.name%</info> command displays all available settings:
 
   <info>php %command.full_name%</info>
@@ -77,7 +77,6 @@ EOF
      * @param InputInterface  $input
      * @param OutputInterface $output
      *
-     * @return void null or 0 if everything went fine, or an error code
      * @see setCode()
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -87,13 +86,13 @@ EOF
         // // Displays all configured domains
         if ($input->getOption('domains')) {
             $tableHeaders = ['Name', 'Priority', 'Enabled', 'Read only'];
-            $tableRows    = [];
+            $tableRows = [];
             foreach ($this->settingsManager->getDomains() as $key => $domain) {
                 $tableRows[] = [
                     $domain->getName(),
                     $domain->getPriority(),
                     $domain->isEnabled(),
-                    $domain->isReadOnly()
+                    $domain->isReadOnly(),
                 ];
             }
             $io->table($tableHeaders, $tableRows);
@@ -108,12 +107,14 @@ EOF
         // Displays table of settings
         if (!$input->getOption('domains') && !$input->getArgument('name')) {
             $tableHeaders = ['Name', 'Description', 'Domain', 'Type', 'Data', 'Provider name', 'Tags'];
-            $tableRows    = [];
+            $tableRows = [];
 
             // Display settings filtered by tags
             if ($tag = $input->getOption('tag')) {
-                foreach (array_reverse($this->settingsManager->getEnabledSettingsByTag($domains,
-                    $tag)) as $settingModel) {
+                foreach (array_reverse($this->settingsManager->getEnabledSettingsByTag(
+                    $domains,
+                    $tag
+                )) as $settingModel) {
                     $tableRows[] = $this->_renderSettingsRow($settingModel);
                 }
             } // Display all settings
@@ -137,11 +138,11 @@ EOF
             $setting = array_shift($setting);
 
             $tableHeaders = ['Option', 'Value'];
-            $tableRows[]  = ['Name', $setting->getName()];
-            $tableRows[]  = ['Description', $setting->getDescription() ?? '-'];
-            $tableRows[]  = ['Domain', $setting->getDomain()->getName()];
-            $tableRows[]  = ['Provider Name', $setting->getProviderName() ?? 'config'];
-            $tableRows[]  = ['Type', $setting->getType()->getValue()];
+            $tableRows[] = ['Name', $setting->getName()];
+            $tableRows[] = ['Description', $setting->getDescription() ?? '-'];
+            $tableRows[] = ['Domain', $setting->getDomain()->getName()];
+            $tableRows[] = ['Provider Name', $setting->getProviderName() ?? 'config'];
+            $tableRows[] = ['Type', $setting->getType()->getValue()];
 
             if ($tags = $setting->getTags()) {
                 $tagInformation = [];
@@ -184,7 +185,7 @@ EOF
             $settingModel->getType()->getValue(),
             $settingModel->getData(),
             $settingModel->getProviderName() ?? 'config',
-            $tagInformation
+            $tagInformation,
         ];
     }
 }

--- a/src/Command/SettingsDebugCommand.php
+++ b/src/Command/SettingsDebugCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Helis\SettingsManagerBundle\Command;
 
 use Helis\SettingsManagerBundle\Model\SettingModel;
-use Helis\SettingsManagerBundle\Provider\SettingsProviderInterface;
 use Helis\SettingsManagerBundle\Settings\SettingsManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -119,11 +118,8 @@ EOF
                 }
             } // Display all settings
             else {
-                /** @var SettingsProviderInterface $provider */
-                foreach (array_reverse($this->settingsManager->getProviders()) as $pName => $provider) {
-                    foreach ($provider->getSettings($domains) as $settingModel) {
-                        $tableRows[] = $this->_renderSettingsRow($settingModel);
-                    }
+                foreach ($this->settingsManager->getSettingsByDomain($domains) as $settingModel) {
+                    $tableRows[] = $this->_renderSettingsRow($settingModel);
                 }
             }
 

--- a/src/Resources/config/command.yml
+++ b/src/Resources/config/command.yml
@@ -6,3 +6,4 @@ services:
 
     Helis\SettingsManagerBundle\Command\WarmUpProvidersCommand: ~
     Helis\SettingsManagerBundle\Command\GenerateKeysCommand: ~
+    Helis\SettingsManagerBundle\Command\SettingsDebugCommand: ~


### PR DESCRIPTION
This Pull Request is a proposal to add a new debug command to help the developer to debug the settings of his application.

###  The debug:settings command displays all available settings:
  
    php bin/console debug:settings
  
###  Use the --domains option to display all configured domains:
  
    php bin/console debug:settings --domains
  
###  Display settings for a specific domain by specifying its name with the --domain option:
  
    php bin/console debug:settings --domain=default
  
###  Find all settings with a specific tag by specifying the tag name with the --tag option:
  
    php bin/console debug:settings --tag=foo