### PR TITLE
added ability to set additional domain names

### DIFF
--- a/src/Settings/SettingsStore.php
+++ b/src/Settings/SettingsStore.php
@@ -67,7 +67,7 @@ class SettingsStore extends ArrayCollection
     }
 
     /**
-     * Checks if settings store is not empty
+     * Checks if settings store is not empty.
      *
      * @return bool
      */

--- a/src/Settings/SettingsStore.php
+++ b/src/Settings/SettingsStore.php
@@ -19,12 +19,18 @@ class SettingsStore extends ArrayCollection
      */
     private $domainNames;
 
+    /**
+     * @var string[]
+     */
+    private $additionalDomainNames;
+
     public function __construct(array $elements = [])
     {
         parent::__construct($elements);
 
         $this->settingsByProvider = [];
         $this->domainNames = [];
+        $this->additionalDomainNames = [];
     }
 
     /**
@@ -60,6 +66,11 @@ class SettingsStore extends ArrayCollection
         return $this->settingsByProvider[$providerName] ?? [];
     }
 
+    /**
+     * Checks if settings store is not empty
+     *
+     * @return bool
+     */
     public function isWarm(): bool
     {
         return $this->count() > 0;
@@ -67,12 +78,28 @@ class SettingsStore extends ArrayCollection
 
     public function getDomainNames(): array
     {
-        return $this->domainNames;
+        if (empty($this->additionalDomainNames)) {
+            return $this->domainNames;
+        }
+
+        return array_values(array_unique(array_merge($this->domainNames, $this->additionalDomainNames)));
     }
 
     public function setDomainNames(array $domainNames): void
     {
         $this->domainNames = $domainNames;
+    }
+
+    public function setAdditionalDomainNames(array $additionalDomainNames): void
+    {
+        $this->additionalDomainNames = $additionalDomainNames;
+    }
+
+    public function addAdditionalDomainName(string $domainName): void
+    {
+        if (!in_array($domainName, $this->additionalDomainNames)) {
+            $this->additionalDomainNames[] = $domainName;
+        }
     }
 
     public function clear()

--- a/tests/src/Unit/Form/SettingFormTypeTest.php
+++ b/tests/src/Unit/Form/SettingFormTypeTest.php
@@ -31,6 +31,7 @@ class SettingFormTypeTest extends TypeTestCase
             ->setType(Type::BOOL())
             ->setData(true);
 
+        # 0: bool as bool
         yield [$formData1, $data1, $object1];
 
         // test string submit
@@ -48,6 +49,7 @@ class SettingFormTypeTest extends TypeTestCase
             ->setDomain(new DomainModel())
             ->setData('2.5678');
 
+        # 1: float as string
         yield [$formData2, $data2, $object2];
 
         // test float submit
@@ -65,24 +67,8 @@ class SettingFormTypeTest extends TypeTestCase
             ->setDomain(new DomainModel())
             ->setData(2.57);
 
+        # 2: float as round float
         yield [$formData3, $data3, $object3];
-
-        // test integer submit
-        $data4 = new SettingModel();
-        $data4->setType(Type::INT());
-
-        $formData4 = [
-            'name' => 'foo',
-            'data' => 2.5678,
-        ];
-
-        $object4 = new SettingModel();
-        $object4
-            ->setType(Type::INT())
-            ->setDomain(new DomainModel())
-            ->setData(2);
-
-        yield [$formData4, $data4, $object4];
     }
 
     /**


### PR DESCRIPTION
This can be useful if some domains are only enabled per locale. So on `kernel.request` event we can `$store->addAdditionalDomainName($request->getLocale())` and domain will be used if its even disabled. Just make sure domain priorities are correct for your needs.