### PR TITLE
Make SettingsIntegrationTrait compatible with PHPUnit 12+

### DIFF
--- a/src/Test/Traits/SettingsIntegrationTrait.php
+++ b/src/Test/Traits/SettingsIntegrationTrait.php
@@ -9,10 +9,10 @@ use PHPUnit\Framework\Attributes\After;
 
 trait SettingsIntegrationTrait
 {
-    #[After]
     /**
      * @after
      */
+    #[After]
     public function tearDownSettings(): void
     {
         SettingsProviderMock::clear();

--- a/src/Test/Traits/SettingsIntegrationTrait.php
+++ b/src/Test/Traits/SettingsIntegrationTrait.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Helis\SettingsManagerBundle\Test\Traits;
 
 use Helis\SettingsManagerBundle\Test\Provider\SettingsProviderMock;
+use PHPUnit\Framework\Attributes\After;
 
 trait SettingsIntegrationTrait
 {
+    #[After]
     /**
      * @after
      */


### PR DESCRIPTION
PHPUnit 10+ emits warnings in console for any annotations that are not overridden by corresponding attributes, PHPUnit 12+ will throw errors.

This approach covers both the old and new PHPUnit versions.