### PR TITLE
Settings in config are not overridden

### DIFF
--- a/src/DependencyInjection/HelisSettingsManagerExtension.php
+++ b/src/DependencyInjection/HelisSettingsManagerExtension.php
@@ -117,7 +117,7 @@ class HelisSettingsManagerExtension extends Extension
 
     private function loadSimpleProvider(array $config, ContainerBuilder $container): void
     {
-        $settings = array_merge(
+        $settings = $this->mergeSettings(
             $config['settings'],
             $this->loadSettingsFromFiles($config['settings_files'], $container)
         );
@@ -186,7 +186,7 @@ class HelisSettingsManagerExtension extends Extension
                     ['helis_settings_manager' => ['settings' => $fileContents]]
                 );
 
-                $settings = array_merge($settings, $processedContents['settings']);
+                $settings = $this->mergeSettings($settings, $processedContents['settings']);
                 $container->addResource(new FileResource($file));
             }
         }
@@ -223,5 +223,14 @@ class HelisSettingsManagerExtension extends Extension
                 ->setPublic(false)
                 ->addTag('kernel.event_subscriber');
         }
+    }
+
+    private function mergeSettings(array $settingsA, array $settingsB): array
+    {
+        $settingsA = array_column($settingsA, null, 'name');
+        $settingsB = array_column($settingsB, null, 'name');
+        $settings = array_merge($settingsA, $settingsB);
+
+        return array_values($settings);
     }
 }

--- a/tests/app/config/config_test.yml
+++ b/tests/app/config/config_test.yml
@@ -77,6 +77,7 @@ helis_settings_manager:
         controller: true
     settings_files:
         - '%kernel.project_dir%/tests/app/config/extra_settings.yml'
+        - '%kernel.project_dir%/tests/app/config/extra_settings_override.yml'
     settings:
         - name: foo
           description: 'foo desc'

--- a/tests/app/config/extra_settings.yml
+++ b/tests/app/config/extra_settings.yml
@@ -1,8 +1,15 @@
-- name: fix
-  description: 'fix desc'
-  domain:
-      name: omg
-      enabled: false
-      read_only: true
-  type: bool
-  data: true
+-   name: fix
+    description: 'fix desc'
+    domain:
+        name: omg
+        enabled: false
+        read_only: true
+    type: bool
+    data: true
+
+
+-   name: overridden_setting
+    description: 'Setting that is overridden'
+    domain: default
+    type: string
+    data: 'initial_value'

--- a/tests/app/config/extra_settings_override.yml
+++ b/tests/app/config/extra_settings_override.yml
@@ -1,0 +1,5 @@
+-   name: overridden_setting
+    description: 'Setting that is overridden'
+    domain: default
+    type: string
+    data: 'overridden_value'

--- a/tests/src/Functional/Settings/SettingsManagerTest.php
+++ b/tests/src/Functional/Settings/SettingsManagerTest.php
@@ -71,7 +71,11 @@ class SettingsManagerTest extends AbstractWebTestCase
 
     public static function getSettingsByDomainDataProvider(): iterable
     {
-        yield [LoadSettingsData::DOMAIN_NAME_1, 7, ['foo', 'baz', 'tuna', 'wth_yaml', 'choice', 'integer', 'bazinga']];
+        yield [
+            LoadSettingsData::DOMAIN_NAME_1,
+            8,
+            ['foo', 'baz', 'tuna', 'wth_yaml', 'choice', 'integer', 'overridden_setting', 'bazinga']
+        ];
 
         yield [LoadSettingsData::DOMAIN_NAME_2, 1, ['tuna']];
     }

--- a/tests/src/Functional/Settings/SettingsManagerTest.php
+++ b/tests/src/Functional/Settings/SettingsManagerTest.php
@@ -74,7 +74,7 @@ class SettingsManagerTest extends AbstractWebTestCase
         yield [
             LoadSettingsData::DOMAIN_NAME_1,
             8,
-            ['foo', 'baz', 'tuna', 'wth_yaml', 'choice', 'integer', 'overridden_setting', 'bazinga']
+            ['foo', 'baz', 'tuna', 'wth_yaml', 'choice', 'integer', 'overridden_setting', 'bazinga'],
         ];
 
         yield [LoadSettingsData::DOMAIN_NAME_2, 1, ['tuna']];

--- a/tests/src/Functional/Settings/SettingsRouterTest.php
+++ b/tests/src/Functional/Settings/SettingsRouterTest.php
@@ -48,6 +48,7 @@ class SettingsRouterTest extends AbstractWebTestCase
                 ['amazing' => ['foo', 'foo', 'foo', 'yee'], 'cool' => ['yes' => ['yes', 'no']], 'damn' => 5],
                 'config',
             ],
+            ['overridden_setting', 'Setting that is overridden', [], Type::STRING, 'overridden_value', 'config'],
         ];
     }
 


### PR DESCRIPTION
Currently config settings are not correctly handling cases when same setting is present in multiple files.

For the following config:
```yaml
helis_settings_manager:
    settings_files:
        - '%kernel.project_dir%/config/settings/extra_settings.yml'
        - '%kernel.project_dir%/config/settings/extra_settings_override.yml'
```

 If you have in `extra_settings_override.yml` a setting, also present in `extra_settings.yml`, the value would be the one from `extra_settings.yml`. This is due to the fact that settings are not deduplicated.